### PR TITLE
Update Sass and Compass login.css.scss example for consistency.

### DIFF
--- a/source/guides/sass-and-compass.html.markdown
+++ b/source/guides/sass-and-compass.html.markdown
@@ -35,7 +35,7 @@ The same styles could also be expressed in the CSS-superset SCSS format in a fil
         float: right; }
     }
 
-Both of these files will compile to the following `build/stylesheets/site.css` file:
+Both of these files will compile to the following `build/stylesheets/login.css` file:
 
     :::css
     body {


### PR DESCRIPTION
Single-line change to indicate that login.css.scss => login.css.
The example was using 'site.css' as its destination, which I think
is outdated.
