### PR TITLE
Add an SCSS example for using the Compass mixins.

### DIFF
--- a/source/guides/sass-and-compass.html.markdown
+++ b/source/guides/sass-and-compass.html.markdown
@@ -66,6 +66,18 @@ CSS3 and Floats:
       +float-right
       +box-shadow(black 0 1px 2px)
 
+The same code in SCSS:
+
+    @import "compass"
+    
+    #main {
+      @include float-left;
+      border: 1px solid black;
+      @include border-radius(5px); }
+    #sidebar {
+      @include float-right;
+      @include box-shadow(black 0 1px 2px); }
+
 Grids (using [Susy]):
 
     @import "susy"


### PR DESCRIPTION
Duplicate the Compass floats example in SCSS to show the use of
Compass mixins in in the SCSS format. This is just to help folks
who haven't used Compass before, and because Sass seems to no
longer be the preferred language.
