### PR TITLE
Fix sidebar to always show entire nav

### DIFF
--- a/source/stylesheets/site.css.sass
+++ b/source/stylesheets/site.css.sass
@@ -32,9 +32,10 @@ body
 .container
   +pie-clearfix
   position: relative
+  min-height: 950px
 
 aside
-  position: fixed
+  position: absolute
   width: 225px
   top: 0
   header


### PR DESCRIPTION
Fix sidebar to always show entire nav. Uses an absolute - instead of fixed - position sidebar, and sets a minimum height on the container.
