### PR TITLE
Fixed "Fork and add your site on Github" link

### DIFF
--- a/source/community/built-using-middleman.html.erb
+++ b/source/community/built-using-middleman.html.erb
@@ -22,5 +22,5 @@
 </ul>
 
 <footer>
-  <%= link_to "Fork and add your site on Github", "https://github.com/middleman/middleman-guides/blob/master/source/built-using-middleman.html.slim" %>
+  <%= link_to "Fork and add your site on Github", "https://github.com/middleman/middleman-guides/blob/master/source/community/built-using-middleman.html.erb" %>
 </footer>


### PR DESCRIPTION
Now it points to the proper file in repo.
