### PR TITLE
Update installation instructions in README

### DIFF
--- a/source/getting-started/welcome.html.markdown
+++ b/source/getting-started/welcome.html.markdown
@@ -16,7 +16,7 @@ Mac OS X comes prepackaged with both Ruby and Rubygems, however, some of the Mid
 
 Once you have Ruby and RubyGems up and running, execute the following from the command line:
 
-    gem install middleman --pre
+    gem install middleman
 
 This will install Middleman, its dependencies and the command-line tools for using Middleman.
 


### PR DESCRIPTION
The README suggest running `gem install middleman --pre` to get `middleman`, which shouldn't be necessary now that 3.0.0 has released, right? If I'm mistaken, please disregard. :)
