### PR TITLE
remove 'Code' section from nav to about.html

### DIFF
--- a/data/nav.yml
+++ b/data/nav.yml
@@ -29,13 +29,3 @@
     -
       title: "Wiki"
       path:  "https://github.com/middleman/middleman/wiki"
--
-  name: "Code"
-  desc: "Source code and code docs"
-  pages:
-    -
-      title: "Repositories"
-      path:  "https://github.com/middleman/"
-    -
-      title: "Code Documentation"
-      path:  "http://rubydoc.info/find/github?q=middleman"

--- a/source/getting-started/about.html.markdown
+++ b/source/getting-started/about.html.markdown
@@ -6,4 +6,9 @@ title: About Middleman
 
 Middleman is a static site generator based on Sinatra. Providing dozens of templating languages (Haml, Sass, Compass, Slim, CoffeeScript, and more). Makes minification, compression, cache busting, Yaml data (and more) an easy part of your development cycle.
 
-Bugs can be reported on the <a href="https://github.com/middleman/middleman/issues">Github Issue Tracker</a>. <a href="https://twitter.com/middlemanapp">Follow Middleman on Twitter</a>.
+## Links
+
+* Bugs can be reported on the <a href="https://github.com/middleman/middleman/issues">Github Issue Tracker</a>. 
+* Follow Middleman on <a href="https://twitter.com/middlemanapp">Twitter</a>.
+* Watch Middleman Repositories on <a href="https://github.com/middleman/">Github</a>.
+* Code Documentation on <a href="http://rubydoc.info/find/github?q=middleman">RubyCoc</a>


### PR DESCRIPTION
Remove 'Code' section from nav to make homepage look better.
And because external link should not place in site navigation, also Github repo link is already at the position above navigation.
