### PR TITLE
Update source/getting-started/about.html.markdown

### DIFF
--- a/source/getting-started/about.html.markdown
+++ b/source/getting-started/about.html.markdown
@@ -11,4 +11,4 @@ Middleman is a static site generator based on Sinatra. Providing dozens of templ
 * Bugs can be reported on the <a href="https://github.com/middleman/middleman/issues">Github Issue Tracker</a>. 
 * Follow Middleman on <a href="https://twitter.com/middlemanapp">Twitter</a>.
 * Watch Middleman Repositories on <a href="https://github.com/middleman/">Github</a>.
-* Code Documentation on <a href="http://rubydoc.info/find/github?q=middleman">RubyCoc</a>
+* Code Documentation on <a href="http://rubydoc.info/find/github?q=middleman">RubyDoc</a>


### PR DESCRIPTION
Fix typo: RubyCoc => RubyDoc
