### PR TITLE
Fix typo in custom extension example.

### DIFF
--- a/source/extensions/custom.html.markdown
+++ b/source/extensions/custom.html.markdown
@@ -41,7 +41,7 @@ module MyFeature
   class Options < Struct.new(:foo, :bar); end
   
   class << self
-    def registered(app, options={}, &block)
+    def registered(app, options_hash={}, &block)
     options = Options.new(options_hash)
     yield options if block_given?
   end


### PR DESCRIPTION
Credit is due to the blog extension.
