### PR TITLE
fix w3c html5 validation error

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <%= stylesheet_link_tag "site" %>
     <%= stylesheet_link_tag "http://fonts.googleapis.com/css?family=Questrial|Arvo" %>
     <title><%= page_title %></title>


### PR DESCRIPTION
fix the following error :

Bad value X-UA-Compatible for attribute http-equiv on element meta.
<meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
