### PR TITLE
Add middleman-livereload to community extensions.

### DIFF
--- a/source/community/3rd-party-extensions.html.erb
+++ b/source/community/3rd-party-extensions.html.erb
@@ -29,6 +29,10 @@ title: "Community Extensions"
     <a href="http://tvaughan.github.com/middleman-deploy/">middleman-deploy</a>
     &mdash; Deploy a Middleman built site over rsync.
   </li>
+  <li>
+    <a href="https://github.com/middleman/middleman-livereload">middleman-livereload</a>
+    &mdash; Automatically refresh the browser when Middleman files change.
+  </li>
 </ul>
 
 <footer>


### PR DESCRIPTION
I've been using middleman-livereload and it works just fine. I think it's time to add it to the middleman guides.
