### PR TITLE
Remove = before the link_to tag (block)

### DIFF
--- a/source/templates/helpers.html.markdown
+++ b/source/templates/helpers.html.markdown
@@ -17,7 +17,7 @@ Padrino provides a `link_to` function that you can use to make link tags. At its
 `link_to` can also take a block, allowing you to provide more complex content for the link:
 
 ``` html
-<%= link_to 'http://mysite.com' do %>
+<% link_to 'http://mysite.com' do %>
   <%= image_tag 'mylogo.png' %>
 <% end %>
 ```


### PR DESCRIPTION
Remove = before the link_to tag on block Link Helper
As suggested on [Issue#383](https://github.com/middleman/middleman/issues/383)
