### PR TITLE
Add bionicspirit.com to `Sites Built Using Middleman`

### DIFF
--- a/source/community/built-using-middleman.html.erb
+++ b/source/community/built-using-middleman.html.erb
@@ -65,6 +65,7 @@ title: "Sites Built Using Middleman"
   <li><a href="http://benhollis.net" target="_blank">http://benhollis.net</a></li>
   <li><a href="http://darrenknewton.com" target="_blank">http://darrenknewton.com</a></li>
   <li><a href="http://thirteen23.com/garage/" target="_blank">http://thirteen23.com/garage/</a></li>
+  <li><a href="https://www.bionicspirit.com/" target="_blank">http://bionicspirit.com</a> (<a href="https://github.com/alexandru/bionicspirit.com">source code</a>)</li>
 </ul>
 
 <footer>


### PR DESCRIPTION
I converted my blog from Jekyll to Middleman.
Thought about adding it to that list :-)

Thanks,
