### PR TITLE
New Zurb Foundation Template (v4.0.3 compatible)

### DIFF
--- a/source/community/3rd-party-project-templates.html.erb
+++ b/source/community/3rd-party-project-templates.html.erb
@@ -18,8 +18,8 @@ title: "Community Project Templates"
     &mdash; HTML5 Boilerplate 3.0 converted to HAML. <a href="http://susy.oddbird.net/">Susy</a> ready.
   </li>
   <li>
-    <a href="https://github.com/vocino/middleman-foundation">Middleman-Foundation</a>
-    &mdash; ZURB Foundation in Compass, SCSS &amp; HAML.
+    <a href="https://github.com/axyz/middleman-zurb-foundation">Middleman-Zurb-Foundation</a>
+    &mdash; ZURB Foundation in Compass, SCSS.
   </li>
   <li>
     <a href="https://github.com/BryanSchuetz/middleman-frameless">Middleman-Frameless</a>


### PR DESCRIPTION
I've made a basic template for the new foundation 4.0.3
I prefer not to bloat it with extra features in order to permit to everyone to adapt it and to make easy every future updates.
I don't know if it possible to integrate it with the vocino's one instead of substitute it, but I've simply done it from scratch and I am quite new on github.
