### PR TITLE
Remove reference to missing html5-haml template

### DIFF
--- a/source/getting-started.html.markdown
+++ b/source/getting-started.html.markdown
@@ -86,18 +86,12 @@ middleman init my_new_mobile_project --template=mobile
     
 ### Included Project Templates
 
-Middleman ships with a number of basic project templates:
+Middleman ships with a number of basic project templates, including:
 
 **[HTML5 Boilerplate](http://html5boilerplate.com/)** 
 
 ``` bash
 middleman init my_new_mobile_project --template=html5
-```
-
-**[HTML5 Boilerplate: HAML & SCSS](https://github.com/dannyprose/Middleman-HTML5BP-HAML)**
-
-``` bash
-middleman init my_new_mobile_project --template=html5-haml
 ```
 
 **[SMACSS](https://github.com/nsteiner/middleman-smacss)**


### PR DESCRIPTION
This template is not shipped with Middleman as of 3.0.12 as far as I can tell.
