### PR TITLE
Replace `source :rubygems` with url for rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem "redcarpet"
 gem "builder"


### PR DESCRIPTION
Bundler (>= 1.3.0) says:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
