### PR TITLE
Highlight code

### DIFF
--- a/source/stylesheets/_base.scss
+++ b/source/stylesheets/_base.scss
@@ -47,3 +47,16 @@ body {
     @include float-right; 
   }
 }
+
+code {
+  background-color: #F8F8F8;
+  margin: 2px;
+  padding: 2px;
+  border-radius: 3px;
+}
+
+pre code {
+  margin: 0px;
+  padding: 2px;
+  display: block;
+}


### PR DESCRIPTION
If `<code>...</code>` is highlighted, this guides will be more user-friendly.

Before:
![ 2013-03-22 3 21 37](https://f.cloud.github.com/assets/290782/287337/27328370-9255-11e2-8af4-89b646220de0.png)

After:
![ 2013-03-22 3 22 28](https://f.cloud.github.com/assets/290782/287338/29ee6b92-9255-11e2-95f1-805b3574bbeb.png)
