### PR TITLE
Add mattonrails.com to "Blogs Using Middleman"

### DIFF
--- a/source/community/built-using-middleman.html.erb
+++ b/source/community/built-using-middleman.html.erb
@@ -79,6 +79,7 @@ title: "Sites Built Using Middleman"
   <li><a href="http://mattolson.com/" target="_blank">http://mattolson.com</a></li>
   <li><a href="http://carl.hoyer.ca/" target="_blank">http://carl.hoyer.ca</a> (<a href="https://github.com/choyer/carl.hoyer.ca">source code</a>)</li>
   <li><a href="http://blog.startae.com.br/" target="_blank">http://blog.startae.com.br</a></li>
+  <li><a href="http://www.mattonrails.com/" target="_blank">http://www.mattonrails.com</a></li>
 </ul>
 
 <footer>


### PR DESCRIPTION
I use `middleman`, `middleman-blog`, and `middleman-sync` to upload the built files to S3. My domain points to my S3 bucket. It's by far my favorite workflow for my personal site and blog.

Cheers
