### PR TITLE
Syntax error in configuration example code

### DIFF
--- a/source/advanced/custom.html.markdown
+++ b/source/advanced/custom.html.markdown
@@ -42,8 +42,9 @@ module MyFeature
 
   class << self
     def registered(app, options_hash={}, &block)
-    options = Options.new(options_hash)
-    yield options if block_given?
+      options = Options.new(options_hash)
+      yield options if block_given?
+    end
   end
 end
 


### PR DESCRIPTION
This pull request fixes the syntax in the block configuration example.
