### PR TITLE
Add middleman-s3_metadata extension

### DIFF
--- a/source/community/3rd-party-extensions.html.erb
+++ b/source/community/3rd-party-extensions.html.erb
@@ -66,6 +66,10 @@ title: "Community Extensions"
     <a href="https://github.com/neo/middleman-gh-pages">middleman-gh-pages</a>
     &mdash; Easy deployment of Middleman sites to Github Pages.
   </li>
+  <li>
+    <a href="https://github.com/qnyp/middleman-s3_metadata">middleman-s3_metadata</a>
+    &mdash; Automates updating metadata (e.g. Content-Type) of specific AWS S3 object.
+  </li>
 </ul>
 
 <h2>Paid Extensions</h2>


### PR DESCRIPTION
I created [middleman-s3_metadata](https://github.com/qnyp/middleman-s3_metadata) extension to automate updating metadata for S3 objects.

Would you merge this?

Thanks,
