### PR TITLE
Fixed wrong url for middleman-combined template

### DIFF
--- a/source/community/3rd-party-project-templates.html.erb
+++ b/source/community/3rd-party-project-templates.html.erb
@@ -72,7 +72,7 @@ title: "Community Project Templates"
     &mdash; A pre-configured Middleman setup for publishing resumes with built-in PDF export
   </li>
   <li>
-    <a href="https://github.com/reefab/ResumeMan">Middleman-Combined</a></a>
+    <a href="https://github.com/nathanlong/middleman-combined">Middleman-Combined</a></a>
     &mdash; A bare-bones template that includes mobile-first, inline media queries with IE support. Great for prototypes.
   </li>
 </ul>


### PR DESCRIPTION
@yterajima caught my error. See aec5bf2. Here's the correct link.
