### PR TITLE
Typo fix

### DIFF
--- a/source/frontmatter.html.markdown
+++ b/source/frontmatter.html.markdown
@@ -27,7 +27,7 @@ my_list:
 </ol>
 ```
 
-Frontmatter must come at the very top of the template and be separated from the rest of the current by a leading and trailing triple hyphen `---`. Inside this block, you can create new data which will be available in the template using the `current_page.data` hash. The `layout` setting will pass directly to Middleman and change which layout is being used for rendering. You can also set `ignore`, `directory_index`, and some other page properties in this way.
+Frontmatter must come at the very top of the template and be separated from the rest of the content by a leading and trailing triple hyphen `---`. Inside this block, you can create new data which will be available in the template using the `current_page.data` hash. The `layout` setting will pass directly to Middleman and change which layout is being used for rendering. You can also set `ignore`, `directory_index`, and some other page properties in this way.
 
 ## JSON Frontmatter
 


### PR DESCRIPTION
Fixes a one-word typo in the Frontmatter page of the guide: “current” should be “content”
