### PR TITLE
Update rubydoc.info paths

### DIFF
--- a/source/advanced/custom.html.markdown
+++ b/source/advanced/custom.html.markdown
@@ -30,9 +30,9 @@ Finally, once your module is included, you must activate it in `config.rb`:
 activate :my_feature
 ```
 
-The [`register`](http://rubydoc.info/gems/middleman/middleman/Middleman/Extensions#register-class_method) method lets you choose the name your extension is activated with. It can also take a block if you want to require files only when your extension is activated.
+The [`register`](http://rubydoc.info/gems/middleman-core/Middleman/Extensions#register-class_method) method lets you choose the name your extension is activated with. It can also take a block if you want to require files only when your extension is activated.
 
-In the `MyFeature` extension, the `initialize` method will be called as soon as the `activate` command is run. The `app` variable is a [`Middleman::Application`](http://rubydoc.info/gems/middleman/middleman/Middleman/Application) class.
+In the `MyFeature` extension, the `initialize` method will be called as soon as the `activate` command is run. The `app` variable is a [`Middleman::Application`](http://rubydoc.info/gems/middleman-core/Middleman/Application) class.
 
 `activate` can also take an options hash (which are passed to `register`) or a block which can be used to configure your extension. You define options with the `options` class method and then access them with `options`:
 
@@ -60,7 +60,7 @@ Passing options to `activate` is generally preferred to setting global variables
 
 ## Setting variables
 
-The [`Middleman::Application`](http://rubydoc.info/github/middleman/middleman/Middleman/Application) class can be used to change global settings (variables using the `set` command) that can be used in your extension.
+The [`Middleman::Application`](http://rubydoc.info/gems/middleman-core/Middleman/Application) class can be used to change global settings (variables using the `set` command) that can be used in your extension.
 
 ``` ruby
 class MyFeature < Middleman::Extension
@@ -140,7 +140,7 @@ Now, inside your templates, you will have access to a `make_a_link` method. Here
 
 ## Sitemap Manipulators
 
-You can modify or add pages in the [sitemap](/advanced/sitemap/) by creating a Sitemap extension. The [`:directory_indexes`](/pretty-urls/) extension uses this feature to reroute normal pages to their directory-index version, and the [blog extension](/blogging/) uses several plugins to generate tag and calendar pages. See [the `Sitemap::Store` class](http://rubydoc.info/github/middleman/middleman/Middleman/Sitemap/Store#register_resource_list_manipulator-instance_method) for more details.
+You can modify or add pages in the [sitemap](/advanced/sitemap/) by creating a Sitemap extension. The [`:directory_indexes`](/pretty-urls/) extension uses this feature to reroute normal pages to their directory-index version, and the [blog extension](/blogging/) uses several plugins to generate tag and calendar pages. See [the `Sitemap::Store` class](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Store#register_resource_list_manipulator-instance_method) for more details.
 
 ``` ruby
 class MyFeature < Middleman::Extension
@@ -212,7 +212,7 @@ class MyFeature < Middleman::Extension
 end
 ```
 
-The [`builder`](http://rubydoc.info/gems/middleman/middleman/Middleman/Cli/Build) parameter is the class that runs the build CLI, and you can use [Thor actions](http://rubydoc.info/github/wycats/thor/master/Thor/Actions) from it.
+The [`builder`](http://rubydoc.info/gems/middleman-core/Middleman/Cli/Build) parameter is the class that runs the build CLI, and you can use [Thor actions](http://rubydoc.info/github/wycats/thor/master/Thor/Actions) from it.
 
 ### compass_config
 

--- a/source/advanced/sitemap.html.markdown
+++ b/source/advanced/sitemap.html.markdown
@@ -6,7 +6,7 @@ title: The Sitemap
 
 Middleman includes a Sitemap, accessible from templates, that can give you information about all the pages and resources in your site and how they relate to each other. This can be used to create navigation, build search pages and feeds, etc.
 
-The [sitemap](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Store) is a repository of every page in your site, including HTML, CSS, JavaScript, images - everything. It also includes any [dynamic pages] you've created using `:proxy`. 
+The [sitemap](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap) is a repository of every page in your site, including HTML, CSS, JavaScript, images - everything. It also includes any [dynamic pages] you've created using `:proxy`. 
 
 ## Seeing the Sitemap
 
@@ -14,11 +14,11 @@ To understand exactly how Middleman sees your site, start the preview server and
 
 ## Accessing the Sitemap from Code
 
-Within templates `sitemap` gets you the sitemap object. From there, you can look at every page via the [`resources`](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Store#resources-instance_method) method or grab individual resources via [`find_resource_by_path`](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Store#find_resource_by_path-instance_method). You can also always get the page object for the page you're currently in via `current_resource`. Once you've got the list of pages from the sitemap, you can filter on various properties using the individual page objects.
+Within templates `sitemap` gets you the sitemap object. From there, you can look at every page via the [`resources`](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Store#resources-instance_method) method or grab individual resources via [`find_resource_by_path`](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Store#find_resource_by_path-instance_method). You can also always get the page object for the page you're currently in via `current_resource`. Once you've got the list of pages from the sitemap, you can filter on various properties using the individual page objects.
 
 ## Sitemap Resources
 
-Each resource in the sitemap is a [Resource](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Resource) object. Resources can tell you all kinds of interesting things about themselves. You can access [frontmatter] data, file extension, source and output paths, a linkable url, etc. Some of the properties of the Resource are mostly useful for Middleman's rendering internals, but you could imagine filtering pages on file extension to find all `.html` files, for example.
+Each resource in the sitemap is a [Resource](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Resource) object. Resources can tell you all kinds of interesting things about themselves. You can access [frontmatter] data, file extension, source and output paths, a linkable url, etc. Some of the properties of the Resource are mostly useful for Middleman's rendering internals, but you could imagine filtering pages on file extension to find all `.html` files, for example.
 
 Each page can also find other pages related to it in the site hierarchy. The `parent`, `siblings`, and `children` methods are particularly useful in building navigation menus and breadcrumbs.
 
@@ -28,7 +28,7 @@ The sitemap can also be queried via an ActiveRecord-like syntax:
 sitemap.where(:tags.include => "homepage").order_by(:priority).limit(10)
 ```
 
-See [Middleman::Sitemap::Queryable](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Queryable) for more on the query interface.
+See [Middleman::Sitemap::Queryable](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Queryable) for more on the query interface.
 
 ## Using the Sitemap in config.rb
 

--- a/source/blogging.html.markdown
+++ b/source/blogging.html.markdown
@@ -238,7 +238,7 @@ If you want to wrap each article in a bit of structure before inserting it into 
 
 The list of articles in your blog is accessible from templates as [`blog.articles`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogData#articles-instance_method), which returns a list of [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle)s.
 
-Each [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle) has some informative methods on it, and can also produce the [`Resource`](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Resource) from the [sitemap](/advanced/sitemap) which has even more information (such as the [`data`](http://rubydoc.info/gems/middleman/middleman/Middleman/Sitemap/Resource#data-instance_method) from your [frontmatter](/frontmatter/))
+Each [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle) has some informative methods on it, and can also produce the [`Resource`](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Resource) from the [sitemap](/advanced/sitemap) which has even more information (such as the [`data`](http://rubydoc.info/gems/middleman-core/Middleman/CoreExtensions/FrontMatter/ResourceInstanceMethods#data-instance_method) from your [frontmatter](/frontmatter/))
 
 For example, the following shows the 5 most-recent articles and their summary:
 


### PR DESCRIPTION
Change links to point to http://rubydoc.info/gems/middleman-core instead
of empty gem http://rubydoc.info/gems/middleman
