### PR TITLE
Add robots.thoughtbot.com to Middleman blogs

### DIFF
--- a/source/community/built-using-middleman.html.erb
+++ b/source/community/built-using-middleman.html.erb
@@ -109,6 +109,7 @@ title: "Sites Built Using Middleman"
   <li><a href="http://oli-g.me/" target="_blank">http://oli-g.me</a> (<a href="https://github.com/oli-g/oli-g.github.io/tree/source">source code</a>)</li>
   <li><a href="http://michaelboeke.com/" target="_blank">http://michaelboeke.com/</a></li>
   <li><a href="http://www.alpine-lab.com/blog" target="_blank">http://www.alpine-lab.com/blog</a></li>
+  <li><a href="http://robots.thoughtbot.com" target="_blank">http://robots.thoughtbot.com</a></li>
 </ul>
 
 <footer>


### PR DESCRIPTION
We moved the thoughtbot blog over to Middleman yesterday. Working well!
