### PR TITLE
Add config.ru content to "getting started"

### DIFF
--- a/source/getting-started.html.markdown
+++ b/source/getting-started.html.markdown
@@ -62,6 +62,15 @@ To include a boilerplate `config.ru` file in your project, add the `--rack` flag
 middleman init my_new_project --rack
 ```
 
+If you've already initialized a project and just want the config.ru for linking with pow or other development server its contents are simply:
+
+```
+require 'rubygems'
+require 'middleman/rack'
+
+run Middleman.server
+```
+
 ### Project Templates
 
 In addition to the default basic skeleton, Middleman comes with several optional project templates based on the [HTML5 Boilerplate] project, [SMACSS], and [Mobile Boilerplate](http://html5boilerplate.com/mobile/). Middleman extensions (like [middleman-blog](/blogging/)) can contribute their own templates as well. Alternative templates can be accessed using the `-T` or `--template` command-line flags. For example, to start a new project based on HTML5 Boilerplate, run this command:


### PR DESCRIPTION
I think it's important to have this in the docs. I wanted to have a config.ru and didn't want to look through the source code to find it. 

Also, it seems like running `middleman init .` is a destructive process.. Oh well!

First used Middleman about 2 years ago for my first backbone project. I'm so stoked to see how far this has come! Great work. Thanks!
