### PR TITLE
Documented sitemap_resorce.url vs sitemap_resource.path for link_to

### DIFF
--- a/source/basics/helpers.html.markdown
+++ b/source/basics/helpers.html.markdown
@@ -62,7 +62,7 @@ Instead of providing the output url for `link_to`, provide either the *source pa
 <ul>
   <% blog.articles.each do |article| %>
     <li>
-      <%= link_to article.title, article.path, relative: true %> <%# Note `article.path` in the second argument %>
+      <%= link_to article.title, article.path, :relative => true %> <%# Note `article.path` in the second argument %>
     </li>
   <% end %>
 </ul>
@@ -70,7 +70,7 @@ Instead of providing the output url for `link_to`, provide either the *source pa
 <ul>
   <% sitemap.resources.select{|resource| resource.data.title}.each do |resource| %>
     <li>
-      <%= link_to resource.data.title, resource, relative: true %> <%# Note `resource` in the second argument %>
+      <%= link_to resource.data.title, resource, :relative => true %> <%# Note `resource` in the second argument %>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
@bhollis was kind to [explain](https://github.com/middleman/middleman/issues/1096#issuecomment-29444434) why `link_to sitemap_resource.data.title, sitemap_resource.url, relative: true` produces an error.

I documented it so that less people will step on the same rake.

To view the resulting text rendered by Github, open it [here](https://github.com/lolmaus/middleman-guides/blob/patch-1/source/basics/helpers.html.markdown) and Ctrl+F/Cmd+F for "If the link_to helper fails to determine".

I'm worried that you may find my writing style not matching documentation style. Feel free to adjust!
