### PR TITLE
Fix broken URLs

### DIFF
--- a/source/advanced/custom.html.markdown
+++ b/source/advanced/custom.html.markdown
@@ -140,7 +140,7 @@ Now, inside your templates, you will have access to a `make_a_link` method. Here
 
 ## Sitemap Manipulators
 
-You can modify or add pages in the [sitemap](/advanced/sitemap/) by creating a Sitemap extension. The [`:directory_indexes`](/pretty-urls/) extension uses this feature to reroute normal pages to their directory-index version, and the [blog extension](/blogging/) uses several plugins to generate tag and calendar pages. See [the `Sitemap::Store` class](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Store#register_resource_list_manipulator-instance_method) for more details.
+You can modify or add pages in the [sitemap](/advanced/sitemap/) by creating a Sitemap extension. The [`:directory_indexes`](/basics/pretty-urls/) extension uses this feature to reroute normal pages to their directory-index version, and the [blog extension](/basics/blogging/) uses several plugins to generate tag and calendar pages. See [the `Sitemap::Store` class](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Store#register_resource_list_manipulator-instance_method) for more details.
 
 ``` ruby
 class MyFeature < Middleman::Extension

--- a/source/basics/blogging.html.markdown
+++ b/source/basics/blogging.html.markdown
@@ -28,11 +28,11 @@ If you already have a Middleman project, you can re-run `middleman init` with th
 
 The blog extension has many configuration options - you can see what they all are and what they do by going to `http://localhost:4567/__middleman/config/` in your preview server.
 
-**Note:** If you are using the [`directory_indexes`](/pretty-urls/) extension, you'll want to make sure that you activate it *after* you activate the blog extension.
+**Note:** If you are using the [`directory_indexes`](/basics/pretty-urls/) extension, you'll want to make sure that you activate it *after* you activate the blog extension.
 
 ## Articles
 
-Like Middleman itself, the blog extension is focused on individual files. Each article is its own file, using any template language you like. The default filename structure for articles is  `{year}-{month}-{day}-{title}.html`. When you want to create a new article, place it in the correct path and include some basic [frontmatter](/frontmatter/) to get going. You can set the `blog.sources` option while activating `:blog` in your `config.rb` to change where and in what format Middleman should look for articles.
+Like Middleman itself, the blog extension is focused on individual files. Each article is its own file, using any template language you like. The default filename structure for articles is  `{year}-{month}-{day}-{title}.html`. When you want to create a new article, place it in the correct path and include some basic [frontmatter](/basics/frontmatter/) to get going. You can set the `blog.sources` option while activating `:blog` in your `config.rb` to change where and in what format Middleman should look for articles.
 
 Let's say I want to create a new post about Middleman. I would create a file at `source/2011-10-18-middleman.html.markdown`. The minimum contents of this file are a `title` entry in the frontmatter:
 
@@ -105,7 +105,7 @@ end
 
 You'd be able to put your article sources at `cats/2013-11-12-best-cats.html` and they'd get written out to `cats/2013/11/12/best-cats.html` without you having to specify a `category` in frontmatter. You can also access the category extracted from the source path via `current_article.metadata[:page]['category']`.
 
-You might also consider enabling the [pretty urls](/pretty-urls/) feature if you want your blog posts to appear as directories instead of HTML files.
+You might also consider enabling the [pretty urls](/basics/pretty-urls/) feature if you want your blog posts to appear as directories instead of HTML files.
 
 
 ## Layouts
@@ -124,7 +124,7 @@ If you want to wrap each article in a bit of structure before inserting it into 
 
 The list of articles in your blog is accessible from templates as [`blog.articles`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogData#articles-instance_method), which returns a list of [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle)s.
 
-Each [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle) has some informative methods on it, and it is also a [`Resource`](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Resource) from the [sitemap](/advanced/sitemap) which has even more information (such as the [`data`](http://rubydoc.info/gems/middleman-core/Middleman/CoreExtensions/FrontMatter/ResourceInstanceMethods#data-instance_method) from your [frontmatter](/frontmatter/)). Within layouts and even your articles themselves you can get the current article via `current_article`,
+Each [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle) has some informative methods on it, and it is also a [`Resource`](http://rubydoc.info/gems/middleman-core/Middleman/Sitemap/Resource) from the [sitemap](/advanced/sitemap) which has even more information (such as the [`data`](http://rubydoc.info/gems/middleman-core/Middleman/CoreExtensions/FrontMatter/ResourceInstanceMethods#data-instance_method) from your [frontmatter](/basics/frontmatter/)). Within layouts and even your articles themselves you can get the current article via `current_article`,
 
 For example, the following shows the 5 most-recent articles and their summary:
 
@@ -191,7 +191,7 @@ There are [several helpers](http://rubydoc.info/github/middleman/middleman-blog/
 
 ## Tags
 
-What would blogging be without organizing articles around tags? Simply add a `tag` entry to your articles' [frontmatter](/frontmatter/). Then, you can access the tags for a [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle) using the [`tag`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle#tags-instance_method) method, and you can get a list of all tags with their associated article from [`blog.tags`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogData#tags-instance_method). If you set the `blog.tag_template` setting in `config.rb` to a template (see [the default config.rb](https://github.com/middleman/middleman-blog/blob/master/lib/middleman-blog/template/config.tt)) you can render a page for each tag. The tag template has the local variable `tagname` set to the current tag and `articles` set to a list of articles with that tag, and you can use the [`tag_path`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/Helpers#tag_path-instance_method) helper to generate links to a particular tag page.
+What would blogging be without organizing articles around tags? Simply add a `tag` entry to your articles' [frontmatter](/basics/frontmatter/). Then, you can access the tags for a [`BlogArticle`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle) using the [`tag`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogArticle#tags-instance_method) method, and you can get a list of all tags with their associated article from [`blog.tags`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/BlogData#tags-instance_method). If you set the `blog.tag_template` setting in `config.rb` to a template (see [the default config.rb](https://github.com/middleman/middleman-blog/blob/master/lib/middleman-blog/template/config.tt)) you can render a page for each tag. The tag template has the local variable `tagname` set to the current tag and `articles` set to a list of articles with that tag, and you can use the [`tag_path`](http://rubydoc.info/github/middleman/middleman-blog/master/Middleman/Blog/Helpers#tag_path-instance_method) helper to generate links to a particular tag page.
 
 The default template produces a [`tag.html`](https://github.com/middleman/middleman-blog/blob/master/lib/middleman-blog/template/source/tag.html.erb) template for you that produces a page for each tag at `tags/{tag}.html`. Adding a couple tags to the above example would look like this:
 
@@ -341,7 +341,7 @@ Time.zone = "Tokyo"
 
 ## Custom Article Collections
 
-Middleman-Blog also supports the ability to group articles by other [frontmatter](/frontmatter/) data as well. A somewhat contrived example would be the ability to group artilces by a *category* attribute:
+Middleman-Blog also supports the ability to group articles by other [frontmatter](/basics/frontmatter/) data as well. A somewhat contrived example would be the ability to group artilces by a *category* attribute:
 
 ```html
 ---
@@ -378,7 +378,7 @@ source/2011-10-18-middleman/photo.jpg
 source/2011-10-18-middleman/source_code.rb
 ```
 
-might be output (if [`directory_indexes`](/pretty-urls/) is turned on) as:
+might be output (if [`directory_indexes`](/basics/pretty-urls/) is turned on) as:
 
 ```
 build/2011/10/18/middleman/index.html

--- a/source/basics/getting-started.html.markdown
+++ b/source/basics/getting-started.html.markdown
@@ -73,7 +73,7 @@ run Middleman.server
 
 ### Project Templates
 
-In addition to the default basic skeleton, Middleman comes with several optional project templates based on the [HTML5 Boilerplate] project, [SMACSS], and [Mobile Boilerplate](http://html5boilerplate.com/mobile/). Middleman extensions (like [middleman-blog](/blogging/)) can contribute their own templates as well. Alternative templates can be accessed using the `-T` or `--template` command-line flags. For example, to start a new project based on HTML5 Boilerplate, run this command:
+In addition to the default basic skeleton, Middleman comes with several optional project templates based on the [HTML5 Boilerplate] project, [SMACSS], and [Mobile Boilerplate](http://html5boilerplate.com/mobile/). Middleman extensions (like [middleman-blog](/basics/blogging/)) can contribute their own templates as well. Alternative templates can be accessed using the `-T` or `--template` command-line flags. For example, to start a new project based on HTML5 Boilerplate, run this command:
 
 ``` bash
 middleman init my_new_boilerplate_project --template=html5

--- a/source/basics/helpers.html.markdown
+++ b/source/basics/helpers.html.markdown
@@ -22,7 +22,7 @@ Padrino provides a `link_to` function that you can use to make link tags. At its
 <% end %>
 ```
 
-Middleman enhances the `link_to` helper to be aware of the [sitemap](/advanced/sitemap/). If you refer to pages in your source folder (with their file extension minus all the template extensions) then `link_to` will generate the correct link, even if you have extensions like [`:directory_indexes`](/pretty-urls/) on. For example, if you had a file `source/about.html` and `:directory_indexes` on, you could link to it like this:
+Middleman enhances the `link_to` helper to be aware of the [sitemap](/advanced/sitemap/). If you refer to pages in your source folder (with their file extension minus all the template extensions) then `link_to` will generate the correct link, even if you have extensions like [`:directory_indexes`](/basics/pretty-urls/) on. For example, if you had a file `source/about.html` and `:directory_indexes` on, you could link to it like this:
 
 ``` html
 <%= link_to 'About', '/about.html' %>
@@ -54,7 +54,7 @@ You can still override individual links to not be relative by adding `:relative 
 
 If the `link_to` helper fails to determine which page the URL provided belongs to, it will use the URL without modifying it. The `:relative_links` option will be ignored in this case, but the `:relative => true` argument will produce an error.
 
-Note that the [`url` method] of the [Sitemap](/advanced/sitemap/) Resource (also inherited by [Blogging](/blogging/) BlogArticle) returns an *output URL*. The `link_to` helper may be unable to match it to a *source path* of the corresponding page/article and thus will be unable to convert it to a relative URL. 
+Note that the [`url` method] of the [Sitemap](/advanced/sitemap/) Resource (also inherited by [Blogging](/basics/blogging/) BlogArticle) returns an *output URL*. The `link_to` helper may be unable to match it to a *source path* of the corresponding page/article and thus will be unable to convert it to a relative URL.
 
 Instead of providing the output url for `link_to`, provide either the *source path* via Resource/BlogArticle [`path` attribute] or simply pass the resource itself as the URL argument for `link_to`. Both will have `link_to` produce relative URLs:
 

--- a/source/basics/pretty-urls.html.markdown
+++ b/source/basics/pretty-urls.html.markdown
@@ -56,7 +56,7 @@ page "/i-really-want-the-extension.html", :directory_index => false
 
 `page` works with regexes or file globs if you want to turn off indexes for many files at once.
 
-You can also add a `directory_index: false` key to your page's [Frontmatter](/frontmatter/) to disable directory indexes.
+You can also add a `directory_index: false` key to your page's [Frontmatter](/basics/frontmatter/) to disable directory indexes.
 
 ## Manual Indexes
 


### PR DESCRIPTION
A bunch of URLs were pointing to pages as if they were still at the root of the site, as opposed to being separated into 'basics' and 'advanced' sections. This fixes that, and should clear up any 404s received when browsing the docs :)
