### PR TITLE
Fixed typo with Susy Grid website listing. Was listed as susy.oddbird.com, but it ...

### DIFF
--- a/source/community/built-using-middleman.html.erb
+++ b/source/community/built-using-middleman.html.erb
@@ -1,5 +1,6 @@
 ---
-title: "Sites Built Using Middleman"
+title: Sites Built Using Middleman
+published: true
 ---
 
 <h1>Sites Built Using Middleman</h1>
@@ -32,7 +33,7 @@ title: "Sites Built Using Middleman"
   <li><a href="http://plantednutrition.com/" target="_blank">http://plantednutrition.com/</a></li>
   <li><a href="http://sskb.umn.edu/" target="_blank">http://sskb.umn.edu/</a></li>
   <li><a href="https://www.findbigmail.com/" target="_blank">https://www.findbigmail.com/</a></li>
-  <li><a href="http://susy.oddbird.com/" target="_blank">http://susy.oddbird.com/</a></li>
+  <li><a href="http://susy.oddbird.net/" target="_blank">http://susy.oddbird.net/</a></li>
   <li><a href="http://sleede.com/" target="_blank">http://sleede.com/</a></li>
   <li><a href="http://www.cyclocane.com" target="_blank">http://www.cyclocane.com</a></li>
   <li><a href="http://merchantos.com" target="_blank">http://merchantos.com</a></li>


### PR DESCRIPTION
...should be susy.oddbird.net.
