### PR TITLE
Add root path to bower asset instructions

### DIFF
--- a/source/basics/asset-pipeline.markdown
+++ b/source/basics/asset-pipeline.markdown
@@ -72,7 +72,7 @@ Sprockets supports Bower, so you can add your Bower components path directly:
 
 ```ruby
 ready do
-  sprockets.append_path 'bower_components'
+  sprockets.append_path File.join root, 'bower_components'
 end
 ```
 


### PR DESCRIPTION
When I tried using bower with middleman, `sprockets.append_path 'bower_components'` would result in bower assets not being found. Adding the `root` to the path fixed the file sourcing error.

Inspired by @headcanon's work (https://github.com/headcanon/middleman-bower-template/blob/master/config.rb)
