### PR TITLE
Added initial Directory Structure docs: middleman-guides/issues#61

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -84,6 +84,8 @@ built:
   - url: http://www.viselectrica.it
   - url: http://www.shannonethomas.com/
   - url: http://ausca.com
+  - url: http://sourcey.com
+    source: https://github.com/sourcey/sourcey.com
 mobile:
   - url: http://pollev.com
 blogs:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -11,6 +11,7 @@ en:
     asset_pipeline: Asset Pipeline
     pretty_urls: Pretty URLs (Directory Indexes)
     livereload: LiveReload
+    directory_structure: Directory Structure
     blogging: Blogging
 
   advanced:

--- a/locales/jp.yml
+++ b/locales/jp.yml
@@ -11,6 +11,7 @@ jp:
     asset_pipeline: アセットパイプライン
     pretty_urls: きれいな URL (ディレクトリインデックス)
     livereload: LiveReload
+    directory_structure: Directory Structure    
     blogging: ブログ機能
 
   advanced:

--- a/source/basics/directory-structure.markdown
+++ b/source/basics/directory-structure.markdown
@@ -1,0 +1,52 @@
+---
+title: Directory Structure
+---
+
+# Directory Structure
+
+The default Middleman installation consists of a directory structure which looks like this:
+
+``` ruby
+mymiddlemansite/
++-- Gemfile
++-- Gemfile.lock
++-- config.rb
++-- source
+    |   .gitignore
+    +-- images
+    ¦   +-- background.png
+    ¦   +-- middleman.png
+    +-- index.html.erb
+    +-- javascripts
+    ¦   +-- all.js
+    +-- layouts
+    ¦   +-- layout.erb
+    +-- stylesheets
+        +-- all.css
+        +-- normalize.css
+```
+
+## Main Directories
+
+Middleman makes use of the `source`, `build`, `data` and `lib` directories for specific purposes. Each of these directories are siblings of the main Middleman directory.
+
+### Source Directory
+
+The `source` directory contains your main website source files to be built, including your templates javascript, CSS and images.
+
+### Build Directory
+
+The `build` directory is where your static website files will be compiled and exported to.
+
+### Data Directory
+
+Local Data allows you to create `.yml`, `.yaml` or `.json` files in a folder called `data` and makes this information available in your templates. The `data` folder should be placed in the root of your project i.e. in the same folder as your project's `source` folder. See the [Local Data](/advanced/local-data/) docs for more information.
+
+### Lib Directory
+
+The `lib` directory enables you to include external Ruby modules which contain [helpers](/basics/helpers/) for building your application. If you use Rails then you will be farmiliar with this layout.
+
+
+
+
+

--- a/source/layouts/_nav.erb
+++ b/source/layouts/_nav.erb
@@ -8,6 +8,7 @@
       <li><a href="<%= locale_prefix %>/basics/dynamic-pages/"><%= t("basics.dynamic_pages") %></a></li>
       <li><a href="<%= locale_prefix %>/basics/asset-pipeline/"><%= t("basics.asset_pipeline") %></a></li>
       <li><a href="<%= locale_prefix %>/basics/pretty-urls/"><%= t("basics.pretty_urls") %></a></li>
+      <li><a href="<%= locale_prefix %>/basics/directory-structure/"><%= t("basics.directory_structure") %></a></li>
       <li><a href="<%= locale_prefix %>/basics/livereload/"><%= t("basics.livereload") %></a></li>
       <li><a href="<%= locale_prefix %>/basics/blogging/"><%= t("basics.blogging") %></a></li>
   </ul>


### PR DESCRIPTION
Hey guys, just finished [porting my site](http://sourcey.com/migrating-from-wordpress-to-middleman/) to Middleman and wanted to say thanks!
- Added initial "Directory Structure" docs which hopefully fixes middleman/middleman-guides#61
- Added Sourcey and source code to "Built Using Middleman"

PS. Wasn't sure about JP translation so I used English. Google Translate says Directory Structure = ディレクトリ構造 but it probably means something completely different ;)
