### PR TITLE
Fix unmatched HTML tag in ERb sample code.

### DIFF
--- a/source/basics/templates.html.markdown
+++ b/source/basics/templates.html.markdown
@@ -24,7 +24,7 @@ If we wanted to get fancy, we could add a loop:
 <h1>Welcome</h1>
 <ul>
   <% 5.times do |num| %>
-    <li>Count <%= num %>
+    <li>Count <%= num %></li>
   <% end %>
 </ul>
 ```


### PR DESCRIPTION
Just making sure the HTML used in the first ERb template is correct (a closing `</li>` tag was missing.)
