### PR TITLE
Add Verge/Vox sites

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -1,4 +1,5 @@
 built:
+  - url: http://www.theverge.com/a/the-verge-50/intro
   - url: http://dahal.co
   - url: http://sass-lang.com
   - url: http://startexploding.com


### PR DESCRIPTION
Vox Media/The Verge is probably one of the biggest media companies to currently use Middleman:

[The Evolution of Tech News Teams](https://source.opennews.org/en-US/learning/evolution-news-apps-teams/)

[Middleman is sweet. The initial @voxdotcom site and now our features use @middlemanapp](https://twitter.com/yurivictor/status/459370603964035073)
