### PR TITLE
a blank space is needed here

### DIFF
--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -37,7 +37,7 @@ layout: layout
   </div>
 
   <div class="container">
-    <p class="intro"><%= t("index.description") %><%= link_to t("index.getting_started"), "#{locale_prefix}/basics/getting-started/" %>.</p>
+    <p class="intro"><%= t("index.description") %> <%= link_to t("index.getting_started"), "#{locale_prefix}/basics/getting-started/" %>.</p>
     <p class="intro sns">
       <span><i class="icon-github"> <%= link_to 'Watch', 'https://github.com/middleman/middleman' %></i></span>
       <span><i class="icon-twitter"> <%= link_to 'Follow @middlemanapp', 'http://twitter.com/middlemanapp' %></i></span>


### PR DESCRIPTION
The index description needs a blank space between the dot and the link to getting started.
