### PR TITLE
Improperly formatted links on the blogging page

### DIFF
--- a/source/basics/blogging.html.markdown
+++ b/source/basics/blogging.html.markdown
@@ -391,8 +391,8 @@ This allows files (e.g. images) that belong to a single blog article to be kept 
 Note that if you want to link to anything in your article subdirectory from your blog post, you should include the directory name:
 
 ```markdown
-Wrong: [My Photo][photo.jpg]
-Right: [My Photo][2011-10-18-middleman/photo.jpg]
+Wrong: [My Photo](photo.jpg)
+Right: [My Photo](2011-10-18-middleman/photo.jpg)
 ```
 
 If you don't do this, it may still work, but other Middleman features like `:asset_hash` won't work. See [this issue](https://github.com/middleman/middleman/issues/818) for more details.


### PR DESCRIPTION
Just a quick fix -- there are a couple of improperly formatted markdown-style links on the blogging page under "Article Subdirectory" section.

See: https://help.github.com/articles/markdown-basics#links
