### PR TITLE
Update Sprockets configuration examples

### DIFF
--- a/source/basics/asset-pipeline.markdown
+++ b/source/basics/asset-pipeline.markdown
@@ -63,9 +63,7 @@ Once you've added a dependency on these gems, any images and fonts from the gem 
 If you want to refer to a gem stylesheet or JS file directly from your HTML rather than including it in your own assets, you'll need to import it explicitly in `config.rb`:
 
 ```ruby
-ready do
-  sprockets.import_asset 'jquery-mobile'
-end
+sprockets.import_asset 'jquery-mobile'
 ```
 
 Then you can refer to that asset directly from `script` tags or `javascript_include_tag`.
@@ -75,17 +73,13 @@ Then you can refer to that asset directly from `script` tags or `javascript_incl
 If you have assets in directories other than your `:js_dir` or `:css_dir`, you can make them importable by adding them to your Sprockets import path. Add this to your `config.rb`:
 
 ```ruby
-ready do
-  sprockets.append_path '/my/shared/assets/'
-end
+sprockets.append_path '/my/shared/assets/'
 ```
 
 Sprockets supports Bower, so you can add your Bower components path directly:
 
 ```ruby
-ready do
-  sprockets.append_path File.join root, 'bower_components'
-end
+sprockets.append_path File.join root, 'bower_components'
 ```
 
 ## Compass

--- a/source/localizable/basics/asset-pipeline.jp.html.markdown
+++ b/source/localizable/basics/asset-pipeline.jp.html.markdown
@@ -51,9 +51,7 @@ gem "bootstrap-sass", :require => false
 アセットファイルとして追加せず, HTML から 直接 gem のスタイルシートや JS ファイルを参照したい場合, `config.rb` の中で明示的に読み込む必要があります。
 
 ```ruby
-ready do
-  sprockets.import_asset 'jquery-mobile'
-end
+sprockets.import_asset 'jquery-mobile'
 ```
 
 これで `script` タグや `javascript_include_tag` から直接参照することができます。
@@ -63,17 +61,13 @@ end
 `:js_dir` や `:css_dir` の他にもアセットディレクトリがある場合, Sprockets のインポートパスを追加することができます。`config.rb` に次の内容を追加してください:
 
 ```ruby
-ready do
-  sprockets.append_path '/my/shared/assets/'
-end
+sprockets.append_path '/my/shared/assets/'
 ```
 
 Sprockets supports Bower, so you can add your Bower components path directly:
 
 ```ruby
-ready do
-  sprockets.append_path 'bower_components'
-end
+sprockets.append_path 'bower_components'
 ```
 
 ## Compass


### PR DESCRIPTION
As of middleman-sprockets v3.3.2, wrapping `sprockets.append_path` or
`sprockets.import_asset` in a `ready` block is no longer necessary.

See: https://github.com/middleman/middleman-sprockets/blob/151a83f2b6f26758fb392cb8d1d315765ab7ab4f/CHANGELOG.md
