### PR TITLE
Fixes link to Frontmatter docs

### DIFF
--- a/source/basics/templates.html.markdown
+++ b/source/basics/templates.html.markdown
@@ -8,11 +8,11 @@ Middleman provides access to many templating languages to simplify your HTML dev
 
 ## Template Basics
 
-The default templating language is ERb. ERb looks exactly like HTML, except it allows you to add variables, call methods and use loops and if statements. The following sections of this guide will use ERb in their examples. 
+The default templating language is ERb. ERb looks exactly like HTML, except it allows you to add variables, call methods and use loops and if statements. The following sections of this guide will use ERb in their examples.
 
 All template files in Middleman include the extension of that templating language in their file name. A simple index page written in ERb would be named `index.html.erb` which includes the full filename, `index.html`, and the ERb extension.
 
-To begin, this file would just contain normal HTML: 
+To begin, this file would just contain normal HTML:
 
 ``` html
 <h1>Welcome</h1>
@@ -33,7 +33,7 @@ If we wanted to get fancy, we could add a loop:
 
 Layouts allow the common HTML surrounding individual pages to be shared across all your templates. Developers coming from PHP will be used to the concept of "header" and "footer" includes which they reference at the top and bottom of every page. The Ruby world, and Middleman, take an inverse approach. The "layout" includes both the header and footer and then wraps the individual page content.
 
-The most basic layout has some shared content and a `yield` call where templates will place their contents. 
+The most basic layout has some shared content and a `yield` call where templates will place their contents.
 
 Here is an example layout using ERb:
 
@@ -45,7 +45,7 @@ Here is an example layout using ERb:
 <body>
   <%= yield %>
 </body>
-</html> 
+</html>
 ```
 
 Given a page template in ERb:
@@ -71,7 +71,7 @@ Regarding file extensions and parsers, layouts have a different function from te
 
 As you might have gathered from the section on templates, file extensions are significant. For example, naming a layout file `layout.html.erb` would tell the language parser that it should take this file, which is erb and turn it into html.
 
-In a sense, reading the extensions from right to left, will tell you the parsings that the file will undergo, ending up as a file in the format of the leftmost extension. In the case of the example, converting an erb file to an html file when serving, and when building the file. 
+In a sense, reading the extensions from right to left, will tell you the parsings that the file will undergo, ending up as a file in the format of the leftmost extension. In the case of the example, converting an erb file to an html file when serving, and when building the file.
 
 Unlike templates, layouts should not be rendered to html. Giving a layout file the leftmost extension `.html` will cause an error when building. Therefore, you should stick to the template language extension only, i.e.: `layout.erb`.
 
@@ -100,7 +100,7 @@ Now, you need to specify which pages use this alternative layout. You can do thi
 page "/admin/*", :layout => "admin"
 ```
 
-This uses a wildcard in the page path to specify that any page under the admin folder should use the admin layout. 
+This uses a wildcard in the page path to specify that any page under the admin folder should use the admin layout.
 
 You can also reference pages directly. For example, let's say we have a `login.html.erb` template which lives in the source folder, but should also have the admin layout. Let's use this example page template:
 
@@ -304,5 +304,5 @@ Stylus                  | .styl                  | stylus
 [Slim]: http://slim-lang.com/
 [Markdown]: http://daringfireball.net/projects/markdown/
 [these guides are written in Markdown]: https://raw.github.com/middleman/middleman-guides/master/source/guides/basics-of-templates.html.markdown
-[Frontmatter]: /frontmatter/
+[Frontmatter]: /basics/frontmatter/
 [Padrino partial helper]: http://www.padrinorb.com/api/classes/Padrino/Helpers/RenderHelpers.html


### PR DESCRIPTION
- Fixes broken link to the Frontmatter page
- Removes extraneous trailing whitespace
