### PR TITLE
Fix directory structure layout

### DIFF
--- a/source/basics/directory-structure.html.markdown
+++ b/source/basics/directory-structure.html.markdown
@@ -8,11 +8,11 @@ The default Middleman installation consists of a directory structure which looks
 
 ``` ruby
 mymiddlemansite/
++-- .gitignore
 +-- Gemfile
 +-- Gemfile.lock
 +-- config.rb
 +-- source
-    |   .gitignore
     +-- images
     ¦   +-- background.png
     ¦   +-- middleman.png


### PR DESCRIPTION
The .gitignore file is a top-level file of the project directory and not in the source
subdirectory.
