### PR TITLE
Update project names to match template installed

### DIFF
--- a/source/basics/getting-started.html.markdown
+++ b/source/basics/getting-started.html.markdown
@@ -100,13 +100,13 @@ Middleman ships with a number of basic project templates, including:
 **[HTML5 Boilerplate]** 
 
 ``` bash
-middleman init my_new_mobile_project --template=html5
+middleman init my_new_html5_project --template=html5
 ```
 
 **[SMACSS]**
 
 ``` bash
-middleman init my_new_mobile_project --template=smacss
+middleman init my_new_smacss_project --template=smacss
 ```
 
 **[Mobile Boilerplate](http://html5boilerplate.com/mobile/)**


### PR DESCRIPTION
These were all mobile projects, which makes me think that perhaps this line was copied rather than created for each of the templates being installed. Thought I'd suggest this for consistency as not all projects created with html5 boilerplate or smacss would be for mobile.
