### PR TITLE
Fix typo blogs to blog in built-using-middleman.html.erb

### DIFF
--- a/source/localizable/community/built-using-middleman.html.erb
+++ b/source/localizable/community/built-using-middleman.html.erb
@@ -3,7 +3,7 @@ title: Sites Built Using Middleman
 published: true
 ---
 
-<% sg = {"title" => data.sites.built, "mobile" => data.sites.mobile, "blogs" => data.sites.blogs} %>
+<% sg = {"title" => data.sites.built, "mobile" => data.sites.mobile, "blog" => data.sites.blogs} %>
 <% sg.each do |site_group, sites| %>
   <h1><%= t("built.#{site_group}") %></h1>
   <ul>


### PR DESCRIPTION
Because of this typo "Blogs Using Middleman" title wasn't showing.
