### PR TITLE
Nested layouts `wrap_layout` needs to be outputted

### DIFF
--- a/source/basics/templates.html.markdown
+++ b/source/basics/templates.html.markdown
@@ -159,7 +159,7 @@ page "blog/*", :layout => :article_layout
 That `layouts/article_layout.erb` layout would look like this
 
 ``` html
-<% wrap_layout :layout do %>
+<%= wrap_layout :layout do %>
   <article>
     <%= yield %>
   </article>


### PR DESCRIPTION
In order for `wrap_layout` to properly work, it needs to be outputted to
using `<%=`. It seems that this is something that recently came about
as it previously was not required. I found this while trying to upgrade
a middleman 3.1 site to 3.3.
