### PR TITLE
Improve visual design of documentation navigation

### DIFF
--- a/source/layouts/article.erb
+++ b/source/layouts/article.erb
@@ -3,7 +3,7 @@
     <%= partial 'partials/global_nav' %>
   </header>
 
-  <div class="container">
+  <div class="body-content-container wrap-container">
     <nav id="toc">
       <%= partial 'layouts/documentation_nav' %>
     </nav>

--- a/source/localizable/_footer.html.erb
+++ b/source/localizable/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="container">
+  <div class="wrap-container">
     <div class="footer-column">
       <article class="footer-site-information">
         <p>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -4,7 +4,7 @@ layout: layout
 
 <header class="hero">
   <%= partial "partials/global_nav" %>
-  <section class="hero-content container" data-js="hero-content">
+  <section class="body-content-container wrap-container" data-js="hero-content">
     <%= link_to image_tag("middleman-logo.svg"), "#{locale_prefix}/",
       class: "headline-content-logo" %>
 
@@ -22,7 +22,7 @@ layout: layout
 </header>
 
 <section class="introduction">
-  <div class="introduction-container container" data-js="introduction-container">
+  <div class="introduction-container wrap-container" data-js="introduction-container">
     <div class="introduction-item">
       <div class="introduction-item-graphic-wrapper">
         <div class="introduction-browser browser">
@@ -105,7 +105,7 @@ layout: layout
 </section>
 
 <section class="featured">
-  <article class="community-social-block container">
+  <article class="community-social-block wrap-container">
     <ul class="centered-content">
       <li class="community-social-link-item github-link">
         <%= link_to "Fork on GitHub",

--- a/source/partials/_global_nav.erb
+++ b/source/partials/_global_nav.erb
@@ -1,5 +1,5 @@
 <nav class="global-nav" data-js="global-nav">
-  <section class="container">
+  <section class="wrap-container">
     <header class="global-nav-item logo-text">
       <%= link_to t("navigation.logo"), "#{locale_prefix}/" %>
     </header>

--- a/source/stylesheets/modules/_documentation-nav.scss
+++ b/source/stylesheets/modules/_documentation-nav.scss
@@ -1,7 +1,6 @@
 #toc {
   @include span-columns(3);
   border-radius: $base-border-radius;
-  border: 1px solid darken($washed-out-gray, 8);
   height: 100vh;
   overflow: scroll;
   padding: .75em;
@@ -46,6 +45,10 @@
 
 .doc-item {
   border-bottom: 1px dotted $base-border-color;
+
+  &:last-child {
+    border: none;
+  }
 
   a {
     color: darken($slate-gray, 20);

--- a/source/stylesheets/modules/_global-nav.scss
+++ b/source/stylesheets/modules/_global-nav.scss
@@ -2,7 +2,6 @@
   height: $global-nav-height;
   transition: 0.3s ease all;
   background-color: $golden-yellow;
-  margin-bottom: 2em;
   padding: 1em 0;
 }
 

--- a/source/stylesheets/modules/_layout.scss
+++ b/source/stylesheets/modules/_layout.scss
@@ -1,4 +1,4 @@
-.container {
+.wrap-container {
   @include outer-container;
   padding: 0 $gutter;
 }
@@ -7,6 +7,10 @@
   @include fill-parent;
   @include clearfix;
   text-align: center;
+}
+
+.body-content-container {
+  margin-top: 4em;
 }
 
 .main {


### PR DESCRIPTION
- Remove `border` from documentation navigation
- Add `margin` below `global-nav` so it's modular and in `content-container`
- Add margin to hero content in lieu of margin from global nav

https://trello.com/c/KNHdE47Q

![screen shot 2014-11-11 at 10 53 18 am](https://cloud.githubusercontent.com/assets/816402/4998928/d253b822-6991-11e4-80b5-dca5fa2107cd.png)
