### PR TITLE
Add title as an example for frontmatter

### DIFF
--- a/source/basics/frontmatter.html.markdown
+++ b/source/basics/frontmatter.html.markdown
@@ -13,6 +13,7 @@ Let's take a simple ERb template, adding some frontmatter variables to change th
 ``` html
 ---
 layout: "custom"
+title: "My Title"
 my_list:
   - one
   - two
@@ -27,7 +28,7 @@ my_list:
 </ol>
 ```
 
-Frontmatter must come at the very top of the template and be separated from the rest of the content by a leading and trailing triple hyphen `---`. Inside this block, you can create new data which will be available in the template using the `current_page.data` hash. The `layout` setting will pass directly to Middleman and change which layout is being used for rendering. You can also set `ignore`, `directory_index`, and some other page properties in this way.
+Frontmatter must come at the very top of the template and be separated from the rest of the content by a leading and trailing triple hyphen `---`. Inside this block, you can create new data which will be available in the template using the `current_page.data` hash, e.g. `title: "My Title"` becomes `current_page.data.title`. The `layout` setting will pass directly to Middleman and change which layout is being used for rendering. You can also set `ignore`, `directory_index`, and some other page properties in this way.
 
 ## JSON Frontmatter
 


### PR DESCRIPTION
Very new users, for better or for worse, might just dive right in and try customizing the
title (like I did). Adding title as an example (since it's probably the
most common frontmatter element) will help them figure out what they're
doing quicker.
