### PR TITLE
Swap Gemfury badge for static version number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Core
 gem 'middleman'
 gem 'middleman-autoprefixer'
+gem 'middleman-data_source'
 gem 'middleman-livereload'
 gem 'middleman-syntax'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    autoprefixer-rails (6.7.2)
+    autoprefixer-rails (6.7.6)
       execjs
     backports (3.6.8)
+    borrower (0.10.0)
     bourbon (5.0.0.beta.7)
       sass (~> 3.4.22)
       thor (~> 0.19.1)
@@ -21,24 +22,23 @@ GEM
     coffee-script-source (1.12.2)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.5)
     contracts (0.13.0)
     dotenv (2.2.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.2.2)
+    eventmachine (1.2.3)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.0.1)
-      addressable (~> 2)
-    ffi (1.9.17)
+    fastimage (2.1.0)
+    ffi (1.9.18)
     haml (4.0.7)
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    hashie (3.5.2)
+    hashie (3.5.5)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.13.2)
@@ -82,6 +82,10 @@ GEM
       servolux
       tilt (~> 2.0)
       uglifier (~> 3.0)
+    middleman-data_source (0.8.1)
+      borrower (~> 0.9)
+      middleman (>= 3.1)
+      rack-test (~> 0.6.2)
     middleman-livereload (3.4.6)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
@@ -90,8 +94,8 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 2.0)
     minitest (5.10.1)
-    neat (1.8.0)
-      sass (>= 3.3)
+    neat (2.0.0)
+      sass (~> 3.4)
       thor (~> 0.19)
     padrino-helpers (0.13.3.3)
       i18n (~> 0.6, >= 0.6.7)
@@ -104,19 +108,21 @@ GEM
     rack (2.0.1)
     rack-livereload (0.3.16)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     redcarpet (3.4.0)
-    rouge (2.0.5)
+    rouge (2.0.7)
     sass (3.4.23)
     servolux (0.12.0)
     thor (0.19.4)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.4)
+    uglifier (3.1.4)
       execjs (>= 0.3.0, < 3)
 
 PLATFORMS
@@ -127,6 +133,7 @@ DEPENDENCIES
   builder
   middleman
   middleman-autoprefixer
+  middleman-data_source
   middleman-livereload
   middleman-syntax
   neat (~> 1.8)

--- a/config.rb
+++ b/config.rb
@@ -14,6 +14,15 @@ activate :external_pipeline,
   source: ".tmp/dist",
   latency: 1
 
+activate :data_source do |d|
+  d.sources = [
+    {
+      alias: "gem_info",
+      path: "https://rubygems.org/api/v1/gems/middleman.json"
+    }
+  ]
+end
+
 proxy "_redirects", "netlify-redirects", ignore: true
 
 page "/", layout: "home"

--- a/source/partials/_hero.erb
+++ b/source/partials/_hero.erb
@@ -10,7 +10,13 @@
         <pre class="browser-body">
           <code class="browser-code"><span class="variable">$</span> <span class="identifier">gem install middleman</span></code>
         </pre>
-        <a class="badge" href="https://badge.fury.io/rb/middleman" target="_blank"><img src="https://badge.fury.io/rb/middleman.svg" alt="Gem Version" height="18"></a>
+
+        <%= link_to(
+          "Current version: #{data.gem_info.version}",
+          data.gem_info.project_uri,
+          class: "version-number",
+          target: "_blank"
+        ) %>
       </div>
     </div>
   </section>

--- a/source/stylesheets/modules/landing/_hero.scss
+++ b/source/stylesheets/modules/landing/_hero.scss
@@ -48,9 +48,12 @@
       @include shift(2);
     }
 
-    .badge {
-      position: absolute;
+    .version-number {
       bottom: 0.75em;
+      color: #fff;
+      font-size: 0.9em;
+      font-weight: 500;
+      position: absolute;
       right: 1em;
     }
   }


### PR DESCRIPTION
The badge is an external resource and adds an extra request to the page.
It is also inaccessible because the version number is within a `img`,
where assistive technology cannot access it.

This commit uses the `middleman-data_source` gem to mount remote JSON
as local data from the RubyGems API, which we can pull the latest
version number from.

See: https://github.com/stevenosloan/middleman-data_source

![screen shot 2017-02-24 at 13 15 52](https://cloud.githubusercontent.com/assets/903327/23316589/0b3e0e5e-fa99-11e6-8fe3-adff0c38d249.png)

---

Note, since this is a statically compiled site, the one downfall with this approach is that when a new gem version is released, the site won’t know about it. We can setup a [GitHub webhook](https://github.com/middleman/middleman-guides/settings/hooks) to send when a new release is published, and for Netlify to listen for that webhook and kick off a new build/deploy: https://www.netlify.com/docs/webhooks/