### PR TITLE
Lock Neat gem into 1.x releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'sass'
 
 # Asset Pipeline Gems
 gem 'bourbon', '>= 5.0.0.beta.7'
-gem 'neat'
+gem 'neat', '~> 1.8'
 
 # Windows Support
 gem 'wdm' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ DEPENDENCIES
   middleman-autoprefixer
   middleman-livereload
   middleman-syntax
-  neat
+  neat (~> 1.8)
   redcarpet
   sass
 


### PR DESCRIPTION
Neat 2.0 was recently released and has major breaking changes from the 1.x release cycle. This locks Neat into 1.x releases until we upgrade.