### PR TITLE
Add a script to run html-proofer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,10 @@ gem 'neat', '~> 1.8'
 # Windows Support
 gem 'wdm' if Gem.win_platform?
 
+group :development do
+  gem 'html-proofer'
+end
+
 # Debug
 # gem 'byebug'
 # gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    colored (1.2)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.5)
@@ -29,6 +30,8 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
     eventmachine (1.2.3)
     execjs (2.7.0)
     fast_blank (1.0.0)
@@ -39,6 +42,15 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashie (3.5.5)
+    html-proofer (3.5.0)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.13.2)
@@ -46,6 +58,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.15.0)
+    mercenary (0.3.6)
     middleman (4.2.1)
       coffee-script (~> 2.2)
       compass-import-once (= 1.0.5)
@@ -93,10 +106,13 @@ GEM
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
+    mini_portile2 (2.1.0)
     minitest (5.10.1)
     neat (1.8.0)
       sass (>= 3.3)
       thor (~> 0.19)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
     padrino-helpers (0.13.3.3)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.3)
@@ -120,10 +136,13 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.6)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.1.4)
       execjs (>= 0.3.0, < 3)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
@@ -131,6 +150,7 @@ PLATFORMS
 DEPENDENCIES
   bourbon (>= 5.0.0.beta.7)
   builder
+  html-proofer
   middleman
   middleman-autoprefixer
   middleman-data_source

--- a/bin/proof
+++ b/bin/proof
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+bundle exec middleman build --verbose
+
+bundle exec htmlproofer --check-html --url-ignore "/localhost:4567/" ./build


### PR DESCRIPTION
html-proofer will check the built site for broken links, among a few other HTML errors.

I’ve been using it to fix a bunch of broken links that we had (e.g. https://github.com/middleman/middlemanapp.com/commit/7e12a6eb2d44cd5cdb3ff9f3ffd4a68f2df6cb95, https://github.com/middleman/middlemanapp.com/commit/60a9361f5e74f15c38fc25fd5a2f6d1ece118dbb, https://github.com/middleman/middlemanapp.com/commit/7fbcdff2f882b3a67ccf2e622f3603ab3e825a19). Having this script makes it _really easy_ to run.

I originally thought to have this as a step in Travis CI, but it broke the build so many time with false positives that I think we should leave it out and just run it manually from time to time.