### PR TITLE
Changes `ignore` to actually working `ignored` config

### DIFF
--- a/source/localizable/basics/frontmatter.html.markdown
+++ b/source/localizable/basics/frontmatter.html.markdown
@@ -30,7 +30,7 @@ my_list:
 </ol>
 ```
 
-Frontmatter must come at the very top of the template and be separated from the rest of the content by a leading and trailing triple hyphen `---`. Inside this block, you can create new data which will be available in the template using the `current_page.data` hash, e.g. `title: "My Title"` becomes `current_page.data.title`. The `layout` setting will pass directly to Middleman and change which layout is being used for rendering. You can also set `ignore`, `directory_index`, and some other page properties in this way.
+Frontmatter must come at the very top of the template and be separated from the rest of the content by a leading and trailing triple hyphen `---`. Inside this block, you can create new data which will be available in the template using the `current_page.data` hash, e.g. `title: "My Title"` becomes `current_page.data.title`. The `layout` setting will pass directly to Middleman and change which layout is being used for rendering. You can also set `ignored`, `directory_index`, and some other page properties in this way.
 
 ## JSON Frontmatter
 


### PR DESCRIPTION
The frontmatter documentation lists `ignore: true` as a way to remove a page. The actual frontmatter setting to hide pages apparently is `ignored: true`. This pull request adjusts the documentation accordingly. 