### PR TITLE
Refactor `active_link_to` helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 # Core
 gem 'middleman'
+gem 'middleman-aria_current'
 gem 'middleman-autoprefixer'
 gem 'middleman-data_source'
 gem 'middleman-livereload'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
       middleman-cli (= 4.2.1)
       middleman-core (= 4.2.1)
       sass (>= 3.4.0, < 4.0)
+    middleman-aria_current (0.1.0)
+      middleman-core (~> 4.2)
     middleman-autoprefixer (2.7.1)
       autoprefixer-rails (>= 6.5.2, < 7.0.0)
       middleman-core (>= 3.3.3)
@@ -152,6 +154,7 @@ DEPENDENCIES
   builder
   html-proofer
   middleman
+  middleman-aria_current
   middleman-autoprefixer
   middleman-data_source
   middleman-livereload

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,7 @@
-activate :i18n
-activate :directory_indexes
+activate :aria_current
 activate :autoprefixer
+activate :directory_indexes
+activate :i18n
 activate :syntax do |syntax|
   syntax.css_class = "syntax-highlight"
 end

--- a/config.rb
+++ b/config.rb
@@ -45,13 +45,3 @@ configure :build do
   activate :minify_css
   activate :minify_javascript
 end
-
-helpers do
-  def active_link_to(caption, url, options = {})
-    if current_page.url == "#{url}/"
-      options[:class] = "doc-item-active"
-    end
-
-    link_to(caption, url, options)
-  end
-end

--- a/helpers/guide_helpers.rb
+++ b/helpers/guide_helpers.rb
@@ -2,7 +2,7 @@ require "pathname"
 
 module GuideHelpers
   def active_link_to(name, url)
-    if current_page.url == "#{url}/"
+    if current_page.url.include?(url)
       link_to(name, url, "aria-current": "page")
     else
       link_to(name, url)

--- a/helpers/guide_helpers.rb
+++ b/helpers/guide_helpers.rb
@@ -1,6 +1,14 @@
 require "pathname"
 
 module GuideHelpers
+  def active_link_to(name, url)
+    if current_page.url == "#{url}/"
+      link_to(name, url, "aria-current": "page")
+    else
+      link_to(name, url)
+    end
+  end
+
   def page_title
     title = "Middleman: "
     if current_page.data.title

--- a/helpers/guide_helpers.rb
+++ b/helpers/guide_helpers.rb
@@ -1,14 +1,6 @@
 require "pathname"
 
 module GuideHelpers
-  def active_link_to(name, url)
-    if current_page.url.include?(url)
-      link_to(name, url, "aria-current": "page")
-    else
-      link_to(name, url)
-    end
-  end
-
   def page_title
     title = "Middleman: "
     if current_page.data.title

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,14 +40,6 @@ en:
       project_templates: Project Templates
       rack_middleware: Rack Middleware
       sitemap: The Sitemap
-    community:
-      title: Open-Source Community
-      built_using_middleman: Sites Built Using Middleman
-      community_forum: Community Forum
-      custom_extensions: Custom Extensions
-      deployment_solution: Deployment Solution
-      github: GitHub Repository
-      project_templates: Project Templates
   open_source:
     title: Contribute to Open Souce
     service: Add Your Service

--- a/locales/jp.yml
+++ b/locales/jp.yml
@@ -40,14 +40,6 @@ jp:
       project_templates: プロジェクトテンプレート
       rack_middleware: Rack ミドルウェア
       sitemap: サイトマップ
-    community:
-      title: コミュニティ
-      built_using_middleman: Middleman 採用サイト
-      community_forum: コミュニティフォーラム
-      custom_extensions: 拡張機能
-      deployment_solution: デプロイ方法
-      github: GitHub リポジトリ
-      project_templates: プロジェクトテンプレート
   open_source:
     title: オープンソースへの貢献
     service: サービスの追加

--- a/source/partials/_documentation_nav.erb
+++ b/source/partials/_documentation_nav.erb
@@ -2,7 +2,11 @@
   <h3 class="docs-section-heading"><%= t("navigation.basics.title") %></h3>
   <ul>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.install"), "#{locale_prefix}/basics/install/"%> </li>
+      <%= active_link_to(
+        t("navigation.basics.install"),
+        "#{locale_prefix}/basics/install/"
+      ) %>
+    </li>
     <li class="doc-item">
       <%= active_link_to t("navigation.basics.upgrade-v4"), "#{locale_prefix}/basics/upgrade-v4/"%> </li>
     <li class="doc-item">

--- a/source/partials/_documentation_nav.erb
+++ b/source/partials/_documentation_nav.erb
@@ -1,5 +1,8 @@
 <div>
-  <h3 class="docs-section-heading"><%= t("navigation.basics.title") %></h3>
+  <h3 class="docs-section-heading">
+    <%= t("navigation.basics.title") %>
+  </h3>
+
   <ul>
     <li class="doc-item">
       <%= active_link_to(
@@ -8,83 +11,163 @@
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.upgrade-v4"), "#{locale_prefix}/basics/upgrade-v4/"%> </li>
-    <li class="doc-item">
-      <%= active_link_to t("navigation.basics.start_new_site"), "#{locale_prefix}/basics/start-new-site/" %>
+      <%= active_link_to(
+        t("navigation.basics.upgrade-v4"),
+        "#{locale_prefix}/basics/upgrade-v4/"
+      ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.directory_structure"), "#{locale_prefix}/basics/directory-structure/" %>
+      <%= active_link_to(
+        t("navigation.basics.start_new_site"),
+        "#{locale_prefix}/basics/start-new-site/"
+      ) %>
     </li>
-    <li class="doc-item" >
-      <%= active_link_to t("navigation.basics.development_cycle"), "#{locale_prefix}/basics/development-cycle/" %>
+    <li class="doc-item">
+      <%= active_link_to(
+        t("navigation.basics.directory_structure"),
+        "#{locale_prefix}/basics/directory-structure/"
+      ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.build_deploy"), "#{locale_prefix}/basics/build-and-deploy/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.development_cycle"),
+        "#{locale_prefix}/basics/development-cycle/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.frontmatter"), "#{locale_prefix}/basics/frontmatter/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.build_deploy"),
+        "#{locale_prefix}/basics/build-and-deploy/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.templates"), "#{locale_prefix}/basics/templating-language/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.frontmatter"),
+        "#{locale_prefix}/basics/frontmatter/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.helper_methods"), "#{locale_prefix}/basics/helper-methods/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.templates"),
+        "#{locale_prefix}/basics/templating-language/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.layouts"), "#{locale_prefix}/basics/layouts/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.helper_methods"),
+        "#{locale_prefix}/basics/helper-methods/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.partials"), "#{locale_prefix}/basics/partials/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.layouts"),
+        "#{locale_prefix}/basics/layouts/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.redirects"), "#{locale_prefix}/basics/redirects/"%> </li>
+      <%= active_link_to(
+        t("navigation.basics.partials"),
+        "#{locale_prefix}/basics/partials/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.basics.blogging"), "#{locale_prefix}/basics/blogging/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.basics.redirects"),
+        "#{locale_prefix}/basics/redirects/"
+      ) %>
+    </li>
+    <li class="doc-item">
+      <%= active_link_to(
+        t("navigation.basics.blogging"),
+        "#{locale_prefix}/basics/blogging/"
+      ) %>
+    </li>
   </ul>
-  </div>
+</div>
 
-  <div class="toc-block">
-  <h3 class="docs-section-heading"><%= t("navigation.advanced.title") %></h3>
+<div class="toc-block">
+  <h3 class="docs-section-heading">
+    <%= t("navigation.advanced.title") %>
+  </h3>
+
   <ul>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.configuration"), "#{locale_prefix}/advanced/configuration/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.configuration"),
+        "#{locale_prefix}/advanced/configuration/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.project_templates"), "#{locale_prefix}/advanced/project-templates/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.project_templates"),
+        "#{locale_prefix}/advanced/project-templates/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.dynamic_pages"), "#{locale_prefix}/advanced/dynamic-pages/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.dynamic_pages"),
+        "#{locale_prefix}/advanced/dynamic-pages/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.data_files"), "#{locale_prefix}/advanced/data-files/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.data_files"),
+        "#{locale_prefix}/advanced/data-files/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.localization"), "#{locale_prefix}/advanced/localization/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.localization"),
+        "#{locale_prefix}/advanced/localization/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.asset_pipeline"), "#{locale_prefix}/advanced/asset-pipeline/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.asset_pipeline"),
+        "#{locale_prefix}/advanced/asset-pipeline/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.external_pipeline"), "#{locale_prefix}/advanced/external-pipeline/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.external_pipeline"),
+        "#{locale_prefix}/advanced/external-pipeline/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.rack_middleware"), "#{locale_prefix}/advanced/rack-middleware/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.rack_middleware"),
+        "#{locale_prefix}/advanced/rack-middleware/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.sitemap"), "#{locale_prefix}/advanced/sitemap/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.sitemap"),
+        "#{locale_prefix}/advanced/sitemap/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.pretty_urls"), "#{locale_prefix}/advanced/pretty-urls/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.pretty_urls"),
+        "#{locale_prefix}/advanced/pretty-urls/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.improving_cacheability"), "#{locale_prefix}/advanced/improving-cacheability/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.improving_cacheability"),
+        "#{locale_prefix}/advanced/improving-cacheability/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.file_size_optimization"), "#{locale_prefix}/advanced/file-size-optimization/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.file_size_optimization"),
+        "#{locale_prefix}/advanced/file-size-optimization/"
+      ) %>
+    </li>
     <li class="doc-item">
-      <%= active_link_to t("navigation.advanced.custom_extensions"), "#{locale_prefix}/advanced/custom-extensions/" %>
-      </li>
+      <%= active_link_to(
+        t("navigation.advanced.custom_extensions"),
+        "#{locale_prefix}/advanced/custom-extensions/"
+      ) %>
+    </li>
   </ul>
 </div>

--- a/source/partials/_documentation_nav.erb
+++ b/source/partials/_documentation_nav.erb
@@ -5,79 +5,79 @@
 
   <ul>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.install"),
         "#{locale_prefix}/basics/install/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.upgrade-v4"),
         "#{locale_prefix}/basics/upgrade-v4/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.start_new_site"),
         "#{locale_prefix}/basics/start-new-site/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.directory_structure"),
         "#{locale_prefix}/basics/directory-structure/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.development_cycle"),
         "#{locale_prefix}/basics/development-cycle/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.build_deploy"),
         "#{locale_prefix}/basics/build-and-deploy/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.frontmatter"),
         "#{locale_prefix}/basics/frontmatter/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.templates"),
         "#{locale_prefix}/basics/templating-language/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.helper_methods"),
         "#{locale_prefix}/basics/helper-methods/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.layouts"),
         "#{locale_prefix}/basics/layouts/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.partials"),
         "#{locale_prefix}/basics/partials/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.redirects"),
         "#{locale_prefix}/basics/redirects/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.basics.blogging"),
         "#{locale_prefix}/basics/blogging/"
       ) %>
@@ -92,79 +92,79 @@
 
   <ul>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.configuration"),
         "#{locale_prefix}/advanced/configuration/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.project_templates"),
         "#{locale_prefix}/advanced/project-templates/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.dynamic_pages"),
         "#{locale_prefix}/advanced/dynamic-pages/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.data_files"),
         "#{locale_prefix}/advanced/data-files/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.localization"),
         "#{locale_prefix}/advanced/localization/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.asset_pipeline"),
         "#{locale_prefix}/advanced/asset-pipeline/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.external_pipeline"),
         "#{locale_prefix}/advanced/external-pipeline/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.rack_middleware"),
         "#{locale_prefix}/advanced/rack-middleware/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.sitemap"),
         "#{locale_prefix}/advanced/sitemap/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.pretty_urls"),
         "#{locale_prefix}/advanced/pretty-urls/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.improving_cacheability"),
         "#{locale_prefix}/advanced/improving-cacheability/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.file_size_optimization"),
         "#{locale_prefix}/advanced/file-size-optimization/"
       ) %>
     </li>
     <li class="doc-item">
-      <%= active_link_to(
+      <%= current_link_to(
         t("navigation.advanced.custom_extensions"),
         "#{locale_prefix}/advanced/custom-extensions/"
       ) %>

--- a/source/stylesheets/modules/_documentation-nav.scss
+++ b/source/stylesheets/modules/_documentation-nav.scss
@@ -38,8 +38,8 @@
       background: lighten($base-accent-color, 30);
     }
   }
-}
 
-.doc-item-active {
-  background: lighten($base-accent-color, 27);
+  [aria-current] {
+    font-weight: $font-weight-bold;
+  }
 }


### PR DESCRIPTION
~~WIP:~~ The `active_link_to` helper is not currently working, ~~and is still not working after these changes. It outputs the link, but no class. Help on figuring that out is greatly appreciated.~~ Update: all good now.

This PR injects and styles off of an `aria-current` attribute instead of a class.

See: http://tink.uk/using-the-aria-current-attribute/

![screen shot 2017-03-18 at 13 58 11](https://cloud.githubusercontent.com/assets/903327/24074726/8494ce30-0be4-11e7-80b9-2105ab917ed7.png)
