### PR TITLE
Add information about how to translate directories to the "Localizing paths" section.

### DIFF
--- a/source/localizable/advanced/localization.html.markdown
+++ b/source/localizable/advanced/localization.html.markdown
@@ -129,6 +129,18 @@ Now, the files would be output as:
 /es/hola.html
 ```
 
+To localize directories, you have to split up the paths. For example, to localize `/services/software-development.html` to `/es/servicios/desarrollo-de-software.html`, you could use the following structure in `locales/es.yml`:
+
+```yaml
+---
+es:
+  paths:
+    services: "servicios"
+    "software-development": "desarrollo-de-software"
+```
+
+    
+
 ## Localizable Templates
 
 By default, the contents of `source/localizable` will be built in multiple


### PR DESCRIPTION
This adds information about how to translate directories. I tried

```yaml
es:
  paths:
    "services/software-development": "servicios/desarrollo-de-software"
```

instead of the correct approach (see diff) and had to look it up in the source. I'd like to add this to the documentation so other people don't have to do the same.

Unfortunately I don't speak Japanese, so someone would have to do the translation. Sorry.