### PR TITLE
Spell blog_calendar correctly in basics/blogging

### DIFF
--- a/source/localizable/basics/blogging.html.markdown
+++ b/source/localizable/basics/blogging.html.markdown
@@ -29,7 +29,7 @@ middleman init MY_BLOG_PROJECT --template=blog
 
 If you already have a Middleman project, you can re-run `middleman init` with
 the blog template option to generate the sample [`index.html`][blog_index],
-[`tag.html`][blog_tag], [`calendar.html`][blog_caldendar], and
+[`tag.html`][blog_tag], [`calendar.html`][blog_calendar], and
 [`feed.xml`][blog_feed], or you can write those yourself. You can see
 [what gets generated][blog_generated] on GitHub.
 


### PR DESCRIPTION
Reference style link for blog_calendar spelled incorrectly as
blog_caldendar. Hyperlink is not being rendered. Fix the spelling in the
body text so the refernce style link can be matched and the hyperlink
displayed.