### PR TITLE
Specify where to apply redirects

### DIFF
--- a/source/localizable/basics/redirects.html.markdown
+++ b/source/localizable/basics/redirects.html.markdown
@@ -14,7 +14,7 @@ feature. Middleman can generate HTML files which will redirect your visitors,
 but, these old paths are likely to still appear in search engines and will
 negatively impact your SEO.
 
-To generate a redirect in Middleman:
+To generate a redirect in Middleman, add the following to `config.rb`:
 
 ```ruby
 redirect "/my/old/path.html", to: "/my/new/path.html"


### PR DESCRIPTION
The existing documentation is unclear on what to do with the example redirect. Users might interpret it as something to run from the command line, or to be added at the top of the file to be redirected. This small change clarifies that redirects must be specified in `config.rb`