### PR TITLE
Add oswaldlabs.com

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -509,3 +509,6 @@ blogs:
   - url: http://www.rmanev.com/
     title: A personal website for Rumen Manev
     source: https://github.com/rum-n/rman3
+  - url: https://oswaldlabs.com
+    title: Oswald Labs
+    source: https://github.com/OswaldFoundation/oswaldlabs.com


### PR DESCRIPTION
We just published the new version of the official website for [Oswald Labs](https://oswaldlabs.com). The source is available on GitHub. Would love to see it in your list. 😄 