### PR TITLE
Link to Rack::Spellcheck example is broken

### DIFF
--- a/source/localizable/advanced/rack-middleware.html.markdown
+++ b/source/localizable/advanced/rack-middleware.html.markdown
@@ -65,4 +65,3 @@ is built.
   [Rack::GoogleAnalytics]: https://github.com/ambethia/rack-google_analytics
   [Rack::Tidy]: https://github.com/rbialek/rack-tidy
   [Rack::Validate]: https://gist.github.com/235715
-  [Rack::SpellCheck]: https://gist.github.com/235097


### PR DESCRIPTION
I would just remove that link