### PR TITLE
Fix link to community forum

### DIFF
--- a/source/localizable/community/index.html.erb
+++ b/source/localizable/community/index.html.erb
@@ -82,7 +82,7 @@
       </p>
       <p class="forum-item-text">
         <%= link_to t("community.forum.link_text"),
-          "https://forum.middlemanapp.com/", class: "forum-cta" %>
+          "https://forum.middlemanapp.com", class: "forum-cta" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
By having a trailing slash, the URL was being transformed to
https://forum.middlemanapp.com/index.html, which is an invalid URL.