### PR TITLE
Adding https://docs.openproject.org

### DIFF
--- a/data/sites.yml
+++ b/data/sites.yml
@@ -590,3 +590,5 @@ blogs:
     title: Gold Frame - Premium Photo Booth Solutions
   - url: https://www.endpoint.com/
     title: End Point custom software development and consulting
+  - url: https://docs.openproject.org/
+    title: Docs for the open source project management software OpenProject


### PR DESCRIPTION
We are using Middleman to generate the docs at OpenProject. Thanks to all contributors of this wonderful project. We really appreciate your effort. We are currently migrating also our website from WordPress to static website generated with Middleman.