### PR TITLE
fix: link to broccoli project

### DIFF
--- a/source/localizable/advanced/external-pipeline.html.markdown
+++ b/source/localizable/advanced/external-pipeline.html.markdown
@@ -183,4 +183,4 @@ module.exports = finalTree;
   [React Native]: https://facebook.github.io/react-native/
   [ClojureScript]: https://clojurescript.org/
   [Elm]: http://elm-lang.org/
-  [Broccoli]: http://broccolijs.com/
+  [Broccoli]: https://broccoli.build/

--- a/source/localizable/advanced/external-pipeline.jp.html.markdown
+++ b/source/localizable/advanced/external-pipeline.jp.html.markdown
@@ -183,4 +183,4 @@ module.exports = finalTree;
   [React Native]: https://facebook.github.io/react-native/
   [ClojureScript]: https://clojurescript.org/
   [Elm]: http://elm-lang.org/
-  [Broccoli]: http://broccolijs.com/
+  [Broccoli]: https://broccoli.build/


### PR DESCRIPTION
The address of the broccoli website changed. I updated the link in the external assets pipeline document.